### PR TITLE
Re-apply original copyright years

### DIFF
--- a/lib_random/api/random.h
+++ b/lib_random/api/random.h
@@ -1,4 +1,4 @@
-// Copyright 2017-2021 XMOS LIMITED.
+// Copyright 2016-2021 XMOS LIMITED.
 // This Software is subject to the terms of the XMOS Public Licence: Version 1.
 #ifndef __RANDOM_H__
 #define __RANDOM_H__

--- a/lib_random/src/random.xc
+++ b/lib_random/src/random.xc
@@ -1,4 +1,4 @@
-// Copyright 2017-2021 XMOS LIMITED.
+// Copyright 2016-2021 XMOS LIMITED.
 // This Software is subject to the terms of the XMOS Public Licence: Version 1.
 #include "random.h"
 #include <xs1.h>

--- a/lib_random/src/random_init.c
+++ b/lib_random/src/random_init.c
@@ -1,4 +1,4 @@
-// Copyright 2017-2021 XMOS LIMITED.
+// Copyright 2016-2021 XMOS LIMITED.
 // This Software is subject to the terms of the XMOS Public Licence: Version 1.
 #include "random.h"
 #include <xs1.h>


### PR DESCRIPTION
Now that the source checker script in infr_apps has been fixed, the original copyright start dates can be re-applied. The previous change to the copyright years was reversed and then the script was re-run to create this diff.